### PR TITLE
Add spm support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+tests

--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,3 @@
+node_modules
+tests
+dist

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/boblauer/MockDate/issues"
   },
-  "homepage": "https://github.com/boblauer/MockDate"
+  "homepage": "https://github.com/boblauer/MockDate",
+  "spm": {
+    "main": "src/mockdate.js"
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/mockdate

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of mockdate in spmjs, I can add it for your account after signing in http://spmjs.io.

spmjs/spm#781