### PR TITLE
Added a way to set a fixed timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockdate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A JavaScript mock Date object that can be used to change when \"now\" is.",
   "main": "./src/mockdate.js",
   "dependencies": {},

--- a/src/mockdate.js
+++ b/src/mockdate.js
@@ -6,6 +6,7 @@
   "use strict";
 
   var _Date = Date
+    , _getTimezoneOffset = Date.prototype.getTimezoneOffset
     , now   = null
     ;
 
@@ -55,10 +56,16 @@
 
   MockDate.prototype = _Date.prototype;
 
-  function set(date) {
+  function set(date, timezone) {
     var dateObj = new Date(date)
     if (isNaN(dateObj.getTime())) {
       throw new TypeError('mockdate: The time set is an invalid date: ' + date)
+    }
+
+    if (timezone !== undefined) {
+      MockDate.prototype.getTimezoneOffset = function() {
+        return timezone;
+      }
     }
 
     Date = MockDate;
@@ -71,6 +78,7 @@
 
   function reset() {
     Date = _Date;
+    Date.prototype.getTimezoneOffset = _getTimezoneOffset
   }
 
   return {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -14,7 +14,13 @@ describe('MockDate', function() {
     , nativeToString = Date.toString()
     ;
 
-  MockDate.set(new Date(mockDate));
+  beforeEach(function () {
+    MockDate.set(new Date(mockDate));
+  });
+
+  afterEach(function () {
+    MockDate.reset();
+  });
 
   it('should throw for bad date', function() {
     assert.throws(function () {
@@ -37,6 +43,11 @@ describe('MockDate', function() {
 
   it('should override Date.parse()', function() {
     assert.equal('807926400000', Date.parse('Wed, 09 Aug 1995 00:00:00 GMT'));
+  });
+
+  it('should override Date.prototype.getTimezoneOffset', function() {
+    MockDate.set(new Date(mockDate), '-1');
+    assert.equal('-1', new Date(mockDate).getTimezoneOffset());
   });
 
   it('should allow mock dates to show up as real dates using instanceof', function() {


### PR DESCRIPTION
I ran into the issue that tests would fail on our CI server, because it was located in a different timezone. By passing a second parameter to `MockDate.set()`, you can fix the timezone offset, e.g. `MockDate.set(new Date(), -60)`