### PR TITLE
Updating prototype reference by using Object.create 

### DIFF
--- a/src/mockdate.js
+++ b/src/mockdate.js
@@ -54,7 +54,7 @@
     return _Date.toString();
   };
 
-  MockDate.prototype = _Date.prototype;
+  MockDate.prototype = Object.create(_Date.prototype);
 
   function set(date, timezoneOffset) {
     var dateObj = new Date(date)


### PR DESCRIPTION
following best practices for javascript, object oriented and prototype.

Its best to do prototype reference using Object.create instead of directly referencing prototype, to safe guard against mutation and various implementation.