### PR TITLE
More useful date examples in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Will restore the original `Date` object back to the native implementation.
 
 ## Example ##
 ```javascript
-MockDate.set('01/30/2000');
+MockDate.set('1/30/2000');
 
 new Date().toString() // "Sun Jan 30 2000 00:00:00 GMT-0600 (CST)"
 

--- a/README.md
+++ b/README.md
@@ -58,21 +58,21 @@ Will restore the original `Date` object back to the native implementation.
 
 ## Example ##
 ```javascript
-MockDate.set('1/1/2000');
+MockDate.set('01/30/2000');
 
-new Date().toString() // "Sat Jan 01 2000 00:00:00 GMT-0600 (CST)"
+new Date().toString() // "Sun Jan 30 2000 00:00:00 GMT-0600 (CST)"
 
-MockDate.set('1/1/2000', 120);
+MockDate.set('1/30/2000', 120);
 
 new Date().getTimezoneOffset() // 120
 
-MockDate.set(new Date('2/2/2000'));
+MockDate.set(new Date('2/20/2000'));
 
-new Date().toString() // "Wed Feb 02 2000 00:00:00 GMT-0600 (CST)"
+new Date().toString() // "Sun Feb 20 2000 00:00:00 GMT-0600 (CST)"
 
-MockDate.set(moment('3/3/2000')); // using momentjs
+MockDate.set(moment('3/30/2000')); // using momentjs
 
-new Date().toString() // "Fri Mar 03 2000 00:00:00 GMT-0600 (CST)"
+new Date().toString() // "Thu Mar 30 2000 00:00:00 GMT-0600 (CST)"
 
 MockDate.reset();
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `Date` to be returned when no parameters are passed to `new Date()`.  Suppor
 
 __date__: __`String`__
 
-The string representation of the `Date` to be returned when no parameters are passed to `new Date()`.
+The string representation of the date which is passed to the `new Date()` constructor. This creates the `Date` to be returned when no parameters are passed to `new Date()`.
 
 __date__: __`Number`__
 
@@ -58,6 +58,10 @@ Will restore the original `Date` object back to the native implementation.
 
 ## Example ##
 ```javascript
+MockDate.set('2000-11-22');
+
+new Date().toString() // "Wed Nov 22 2000 00:00:00 GMT-0600 (CST)"
+
 MockDate.set('1/30/2000');
 
 new Date().toString() // "Sun Jan 30 2000 00:00:00 GMT-0600 (CST)"


### PR DESCRIPTION
A lot of the world represent the date as `DD/MM/YYYY`
So I just wanted to make the behaviour unambiguous in the examples by giving a day > 12.