### PR TITLE
TypeScript definition is incorrect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,6 @@
 //                 Kav Singh <https://github.com/kavsingh>
 
 export = {
-  set(date: Date | string | number, timezoneOffset?: number): void;
+  set(date: Date | string | number, timezoneOffset?: number): void,
   reset(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Bruno Konrad <https://github.com/brunoskonrad>
 //                 Kav Singh <https://github.com/kavsingh>
 
-export default class MockDate {
-  static set(date: Date | string | number, timezoneOffset?: number): void;
-  static reset(): void;
+export = {
+  set(date: Date | string | number, timezoneOffset?: number): void;
+  reset(): void;
 }


### PR DESCRIPTION
This module doesn't make a default export, it assigns to module.exports; so it should use `export = ` syntax.

It also doesn't declare an actual class, it just returns an object with set and reset. So this also returns a more accurate type signature.