### PR TITLE
Delete internal type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,0 @@
-// Type definitions for mockdate 2.0.2
-// Project: mockdate
-// Definitions by: Bruno Konrad <https://github.com/brunoskonrad>
-//                 Kav Singh <https://github.com/kavsingh>
-
-export = {
-  set(date: Date | string | number, timezoneOffset?: number): void,
-  reset(): void;
-}


### PR DESCRIPTION
In favor of @types/mockdate. To allow community (instead of @boblauer) to maintain types.

Fix: #26 #31 