### PR TITLE
Fixed broken ts definitions from @types/mockdate

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,18 @@
-// Type definitions for mockdate 2.0.2
-// Project: mockdate
-// Definitions by: Bruno Konrad <https://github.com/brunoskonrad>
-//                 Kav Singh <https://github.com/kavsingh>
+// Type definitions for mockdate 2.0
+// Project: https://github.com/boblauer/MockDate
+// Definitions by: Bruno Leonardo Michels <https://github.com/brunolm>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = {
-  set(date: Date | string | number, timezoneOffset?: number): void,
-  reset(): void;
-}
+export as namespace MockDate;
+
+/**
+ * Change the Date implementation to mock a specific date.
+ * @param Date to be set as current
+ * @param timezoneOffset? The value that should be returned by new Date().getTimezoneOffset()
+ */
+export function set(date: { valueOf(): number; } | number | string, timezoneOffset?: number): void;
+
+/**
+ * Restore the original Date object back to the native implementation.
+ */
+export function reset(): void;


### PR DESCRIPTION
Old version raises error:
`node_modules/mockdate/index.d.ts(7,67): error TS1005: '{' expected.`