### PR TITLE
Add prettier and setMultiple new function

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "jsxBracketSameLine": true
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var MockDate = window.MockDate;
 ```
 
 ## API ##
-```javascript;
+```javascript
 MockDate.set(date, [timezoneOffset])
 ```
 
@@ -49,6 +49,12 @@ The millisecond representation of the `Date` to be returned when no parameters a
 __timezoneOffset__: __`Number`__
 
 The value that should be returned by new Date().getTimezoneOffset()
+
+```javascript
+MockDate.setMultiple(dates, [timezoneOffset])
+```
+
+Same as set method, but you can pass multiple dates, so each new Date instance will get a mock of the array (at the order inputed, FIFO queue) until it stops on the last date inputed.
 
 ```javascript
 MockDate.reset();
@@ -77,6 +83,18 @@ new Date().toString() // "Sun Feb 20 2000 00:00:00 GMT-0600 (CST)"
 MockDate.set(moment('3/30/2000')); // using momentjs
 
 new Date().toString() // "Thu Mar 30 2000 00:00:00 GMT-0600 (CST)"
+
+MockDate.setMultiple([new Date(2020, 0, 17), new Date(2020, 0, 24)], 120)
+
+const begin = new Date()
+begin.toString() // "Fri Jan 17 2020 00:00:00 GMT-0600 (CST)"
+
+const end = new Date()
+end.toString() // "Fri Jan 24 2020 00:00:00 GMT-0600 (CST)"
+
+end - begin // diffs to fixed 604800000ms (1 week)
+
+new Date().getTimezoneOffset() // 120
 
 MockDate.reset();
 

--- a/src/mockdate.js
+++ b/src/mockdate.js
@@ -1,23 +1,23 @@
 (function(name, definition) {
   if (typeof module !== 'undefined') module.exports = definition();
-  else if (typeof define === 'function' && typeof define.amd === 'object') define(definition);
+  else if (typeof define === 'function' && typeof define.amd === 'object')
+    define(definition);
   else this[name] = definition();
-}('MockDate', function() {
-  "use strict";
+})('MockDate', function() {
+  'use strict';
 
-  var _Date = Date
-    , _getTimezoneOffset = Date.prototype.getTimezoneOffset
-    , now   = null
-    ;
-
+  var _Date = Date,
+    _getTimezoneOffset = Date.prototype.getTimezoneOffset,
+    now = null,
+    multiple = [];
   function MockDate(y, m, d, h, M, s, ms) {
     var date;
 
     switch (arguments.length) {
-
       case 0:
         if (now !== null) {
           date = new _Date(now);
+          shiftMultiple();
         } else {
           date = new _Date();
         }
@@ -57,15 +57,15 @@
   MockDate.prototype = _Date.prototype;
 
   function set(date, timezoneOffset) {
-    var dateObj = new Date(date)
+    var dateObj = new Date(date);
     if (isNaN(dateObj.getTime())) {
-      throw new TypeError('mockdate: The time set is an invalid date: ' + date)
+      throw new TypeError('mockdate: The time set is an invalid date: ' + date);
     }
 
     if (typeof timezoneOffset === 'number') {
       MockDate.prototype.getTimezoneOffset = function() {
         return timezoneOffset;
-      }
+      };
     }
 
     Date = MockDate;
@@ -73,14 +73,40 @@
     now = dateObj.valueOf();
   }
 
+  function shiftMultiple(timezoneOffset) {
+    if (multiple && multiple.length > 0) {
+      set(multiple.shift(), timezoneOffset);
+    }
+  }
+
+  function setMultiple(dates, timezoneOffset) {
+    if (!dates || dates.length == 0) {
+      throw new TypeError(
+        'mockdate: Received an empty array of dates on setMultiple, pass at least one valid date'
+      );
+    }
+
+    if (isNaN(dates[0].getTime())) {
+      throw new TypeError(
+        'mockdate: Pass at least one valid date to setMultiple, first elment of array is an invalid date: ' +
+          dates[0]
+      );
+    }
+
+    multiple = dates.slice();
+
+    shiftMultiple(timezoneOffset);
+  }
+
   function reset() {
+    multiple = [];
     Date = _Date;
-    Date.prototype.getTimezoneOffset = _getTimezoneOffset
+    Date.prototype.getTimezoneOffset = _getTimezoneOffset;
   }
 
   return {
     set: set,
-    reset: reset
+    setMultiple: setMultiple,
+    reset: reset,
   };
-
-}));
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2,29 +2,38 @@ const should = require('should');
 const MockDate = require('..');
 
 describe('MockDate', function() {
-
   var mockDate = '1/1/2000';
   var currentYear = new Date().getFullYear();
   var nativeToString = Date.toString();
   var mockDateRealOffset = new Date(mockDate).getTimezoneOffset();
   var currentDateRealOffset = new Date().getTimezoneOffset();
 
-  beforeEach(function () {
+  beforeEach(function() {
     MockDate.set(new Date(mockDate));
   });
 
-  afterEach(function () {
+  afterEach(function() {
     MockDate.reset();
   });
 
   it('should throw for bad date', function() {
-    should.throws(function () {
+    should.throws(function() {
       MockDate.set('40/40/2000');
-    }, 'mockdate: The time set is an invalid date: 40/40/2000');
+    }, 'mockdate: Received an empty array of dates on setMultiple, pass at least one valid date');
 
-    should.throws(function () {
+    should.throws(function() {
       MockDate.set(NaN);
+    }, 'mockdate: Pass at least one valid date to setMultiple, first elment of array is an invalid date: NaN');
+  });
+
+  it('should throw for bad dates', function() {
+    should.throws(function() {
+      MockDate.setMultiple(NaN);
     }, 'mockdate: The time set is an invalid date: NaN');
+
+    should.throws(function() {
+      MockDate.setMultiple(['40/40/2000']);
+    }, 'mockdate: The time set is an invalid date: 40/40/2000');
   });
 
   it('should override new Date()', function() {
@@ -73,14 +82,14 @@ describe('MockDate', function() {
 
   it('should be able to create a specific date from year, month', function() {
     var locDate = new Date(1995, 7);
-    var utcMs   = locDate.valueOf()-locDate.getTimezoneOffset()*60*1000;
+    var utcMs = locDate.valueOf() - locDate.getTimezoneOffset() * 60 * 1000;
     var utcDate = new Date(utcMs);
     should.equal('Tue, 01 Aug 1995 00:00:00 GMT', utcDate.toUTCString());
   });
 
   it('should be able to create a specific date from year, month, date', function() {
     var locDate = new Date(1995, 7, 9);
-    var utcMs   = locDate.valueOf()-locDate.getTimezoneOffset()*60*1000;
+    var utcMs = locDate.valueOf() - locDate.getTimezoneOffset() * 60 * 1000;
     var utcDate = new Date(utcMs);
     should.equal('Wed, 09 Aug 1995 00:00:00 GMT', utcDate.toUTCString());
   });
@@ -93,6 +102,27 @@ describe('MockDate', function() {
   it('should be able to create a date correctly from the epoch', function() {
     MockDate.set(0);
     should.equal('Thu, 01 Jan 1970 00:00:00 GMT', new Date().toUTCString());
+  });
+
+  it('should set multiple dates and use it in cycles', function() {
+    const dates = [
+      new Date(2020, 0, 19),
+      new Date(2020, 0, 20),
+      new Date(1991, 0, 10),
+    ];
+    const timezoneOffset = 0;
+
+    MockDate.setMultiple(dates, timezoneOffset);
+    const firstDate = new Date();
+    const secondDate = new Date();
+    const thirdDate = new Date();
+    const fourthDate = new Date();
+
+    should.equal(timezoneOffset, firstDate.getTimezoneOffset());
+    should.equal(dates[0].toString(), firstDate.toString());
+    should.equal(dates[1].toString(), secondDate.toString());
+    should.equal(dates[2].toString(), thirdDate.toString());
+    should.equal(dates[2].toString(), fourthDate.toString());
   });
 
   it('should revert correctly', function() {


### PR DESCRIPTION
Fix https://github.com/boblauer/MockDate/issues/37

Copying example on the issue and now on README:

```js
MockDate.setMultiple([new Date(2020, 0, 17), new Date(2020, 0, 24)], 120)

const begin = new Date()
begin.toString() // "Fri Jan 17 2020 00:00:00 GMT-0600 (CST)"

const end = new Date()
end.toString() // "Fri Jan 24 2020 00:00:00 GMT-0600 (CST)"

end - begin // diffs to fixed 604800000ms (1 week)
```
