### PR TITLE
#47 Add option to allow time to advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ import MockDate from 'mockdate'
 ```
 
 ## API ##
-```javascript;
+```javascript
 MockDate.set(date)
+```
+
+```javascript
+MockDate.set(date, advanceTime)
 ```
 
 #### __date__
@@ -34,6 +38,10 @@ The string representation of the date which is passed to the `new Date()` constr
 __date__: __`Number`__
 
 The millisecond representation of the `Date` to be returned when no parameters are passed to `new Date()`.
+
+__advanceTime__: __`boolean`__ *(Optional)*
+
+If set to `true`, time will advance forward relative to the `Date` parameter provided. Each time MockDate is used to get a new Date instance, it will be offset forward the amount of time that has passed since setting the date with `MockDate.set`
 
 ```javascript
 MockDate.reset();
@@ -62,6 +70,13 @@ new Date().toString() // "Thu Mar 30 2000 00:00:00 GMT-0600 (CST)"
 MockDate.reset();
 
 new Date().toString() // "Mon Mar 17 2014 18:08:44 GMT-0500 (CDT)"
+
+// With advanceTime set to true
+MockDate.set(new Date('2/20/2000'), true);
+
+new Date().toString() // "Sun Feb 20 2000 00:00:00 GMT-0600 (CST)"
+// ... 5 seconds later
+new Date().toString() // "Sun Feb 20 2000 00:00:05 GMT-0600 (CST)"
 ```
 
 ## Test ##

--- a/src/mockdate.ts
+++ b/src/mockdate.ts
@@ -1,5 +1,6 @@
 const RealDate = Date;
 let now: null | number = null;
+let start: null | number = null;
 
 class MockDate extends Date {
   constructor();
@@ -14,7 +15,13 @@ class MockDate extends Date {
     switch (arguments.length) {
       case 0:
         if (now !== null) {
-          date = new RealDate(now.valueOf());
+          if(start == null) {
+            date = new RealDate(now.valueOf());
+          }
+          else {
+            const delta = RealDate.now().valueOf() - start.valueOf();
+            date = new RealDate(now.valueOf() + delta);
+          }
         } else {
           date = new RealDate();
         }
@@ -54,7 +61,7 @@ MockDate.toString = function() {
   return RealDate.toString();
 };
 
-export function set(date: string | number | Date): void {
+export function set(date: string | number | Date, advanceTime?: boolean): void {
   var dateObj = new Date(date.valueOf())
   if (isNaN(dateObj.getTime())) {
     throw new TypeError('mockdate: The time set is an invalid date: ' + date)
@@ -68,6 +75,9 @@ export function set(date: string | number | Date): void {
   }
 
   now = dateObj.valueOf();
+  if(advanceTime === true) {
+    start = RealDate.now();
+  }
 }
 
 export function reset(): void {

--- a/test/index.js
+++ b/test/index.js
@@ -82,4 +82,14 @@ describe('MockDate', function() {
     should.equal(new Date().getFullYear(), currentYear);
     should.ok(Date.toString().indexOf('native'));
   });
+
+  it('should allow advancing of time since set date', function(done) {
+    var start = new Date(2018, 6, 1);
+    MockDate.set(start, true);
+    should.equal(new Date().toUTCString(), 'Sun, 01 Jul 2018 04:00:00 GMT');
+    setTimeout(() => {
+      should.equal(new Date().toUTCString(), 'Sun, 01 Jul 2018 04:00:01 GMT');
+      done();
+    }, 1000)
+  });
 });


### PR DESCRIPTION
Adds a boolean parameter to `MockDate.set` method which allows time to advance relative to date used for mock date.
Reference issue #47 