### PR TITLE
Change constructor name to 'Date'

### DIFF
--- a/src/mockdate.ts
+++ b/src/mockdate.ts
@@ -1,7 +1,7 @@
 const RealDate = Date;
 let now: null | number = null;
 
-class MockDate extends Date {
+const MockDate = class Date extends RealDate {
   constructor();
   constructor(value: number | string);
   constructor(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number);

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,10 @@ describe('MockDate', function() {
     MockDate.reset();
   });
 
+  it('should check date constructor name', function() {
+    should.equal(Date.name, 'Date');
+  });
+
   it('should throw for bad date', function() {
     should.throws(function () {
       MockDate.set('40/40/2000');


### PR DESCRIPTION
Some tools (e.g. Mongoose) need `Date` to have this constructor name.