### PR TITLE
- Create as native ESM; refactor tests to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,18 @@
   "name": "mockdate",
   "version": "3.0.5",
   "description": "A JavaScript mock Date object that can be used to change when \"now\" is.",
-  "main": "lib/mockdate.js",
+  "main": "./lib/mockdate.cjs",
+  "type": "module",
   "types": "lib/mockdate.d.ts",
   "dependencies": {},
+  "exports": {
+    "types": "./lib/mockdate.d.ts",
+    "import": "./lib/mockdate.js",
+    "require": "./lib/mockdate.cjs"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "devDependencies": {
     "mocha": "7.1.2",
     "rollup": "2.42.4",
@@ -30,12 +39,15 @@
     "test"
   ],
   "author": "Bob Lauer <rlauer@gmail.com>",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/boblauer/MockDate/issues"
   },
   "homepage": "https://github.com/boblauer/MockDate",
   "spm": {
-    "main": "lib/mockdate.js"
+    "main": "lib/mockdate.cjs"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,20 @@
 import typescript from 'rollup-plugin-typescript2';
 
-export default {
+export default [{
   input: 'src/mockdate.ts',
-  output: [
-    {
-      file: 'lib/mockdate.js',
-      format: 'umd',
-      name: 'MockDate',
-    },
-  ],
+  output: {
+    exports: 'named',
+    file: 'lib/mockdate.cjs',
+    format: 'umd',
+    name: 'MockDate',
+  },
   plugins: [typescript()],
-};
+}, {
+  input: 'src/mockdate.ts',
+  output: {
+    file: 'lib/mockdate.js',
+    format: 'esm',
+    name: 'MockDate',
+  },
+  plugins: [typescript()],
+}];

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-const should = require('should');
-const MockDate = require('../lib/mockdate');
+import should from 'should';
+import MockDate from '../lib/mockdate.js';
 
 describe('MockDate', function() {
   const mockDate = '1/1/2000';


### PR DESCRIPTION
This is a breaking change in adding `engines` to 12 (though Node 10 is now [EOL](https://nodejs.org/en/about/releases/)).

It is also breaking because now only the paths added to `exports` are available, but I imagine providing the UMD and ESM distribution files as well as TypeScript declaration file should be all that ought to be desirable.